### PR TITLE
Update boundwize/structarmed to version 0.6.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.6.16",
+        "boundwize/structarmed": "^0.6.17",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f67b133324f714efa4be8dc430c8f709",
+    "content-hash": "9945f16c86858880ae6adf631bc61d99",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.6.16` to `0.6.17`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`