### PR TITLE
Update boundwize/structarmed to version 0.7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.4",
+        "boundwize/structarmed": "^0.7.5",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bc793b83244ec3a8032a33be3537159",
+    "content-hash": "75a20f27c49bebed7befe6cf14727039",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.4",
+            "version": "0.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "9e3216565e7d6f55ea63fbe3ed6082117228887f"
+                "reference": "6d3e9b3890048fba0277e961f26f0bc08fe00d3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/9e3216565e7d6f55ea63fbe3ed6082117228887f",
-                "reference": "9e3216565e7d6f55ea63fbe3ed6082117228887f",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/6d3e9b3890048fba0277e961f26f0bc08fe00d3f",
+                "reference": "6d3e9b3890048fba0277e961f26f0bc08fe00d3f",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.4"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.5"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T23:57:28+00:00"
+            "time": "2026-05-22T06:54:53+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -148,16 +148,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "6a490267228b3bdd902bc716dc8cb787af69db03"
+                "reference": "c384125d81e7cee7c8abffe550d972343d377cb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/6a490267228b3bdd902bc716dc8cb787af69db03",
-                "reference": "6a490267228b3bdd902bc716dc8cb787af69db03",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/c384125d81e7cee7c8abffe550d972343d377cb9",
+                "reference": "c384125d81e7cee7c8abffe550d972343d377cb9",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.4",
+                "boundwize/structarmed": "^0.7.5",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -268,7 +268,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-22T02:16:14+00:00"
+            "time": "2026-05-22T07:32:53+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.4` to `0.7.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`