### PR TITLE
Update boundwize/structarmed to version 0.7.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.6",
+        "boundwize/structarmed": "^0.7.7",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/testify": "^0.1.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a04ef02434f62225db2721d89314898",
+    "content-hash": "5b093379eb34df0b5121cfb5ba470d67",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.6",
+            "version": "0.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "27222c45da6e7c7a0eefac55c6e85359bdb29305"
+                "reference": "3a050e463fc8f167896f0da257aaad007c7e7b98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/27222c45da6e7c7a0eefac55c6e85359bdb29305",
-                "reference": "27222c45da6e7c7a0eefac55c6e85359bdb29305",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/3a050e463fc8f167896f0da257aaad007c7e7b98",
+                "reference": "3a050e463fc8f167896f0da257aaad007c7e7b98",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.6"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.7"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-22T14:00:28+00:00"
+            "time": "2026-05-24T09:34:07+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -237,16 +237,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "5074a7406f1a00758796840d0b581b79e868bb39"
+                "reference": "19a9bf54edeb51282b9b4149f2b46da932a65b46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5074a7406f1a00758796840d0b581b79e868bb39",
-                "reference": "5074a7406f1a00758796840d0b581b79e868bb39",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/19a9bf54edeb51282b9b4149f2b46da932a65b46",
+                "reference": "19a9bf54edeb51282b9b4149f2b46da932a65b46",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.6",
+                "boundwize/structarmed": "^0.7.7",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -357,7 +357,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-24T03:53:55+00:00"
+            "time": "2026-05-24T10:00:25+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.6` to `0.7.7`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`