### PR TITLE
Update boundwize/structarmed to version 0.7.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.9",
+        "boundwize/structarmed": "^0.7.10",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/testify": "^0.1.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23a369347509a8d2d9d5c429c9891414",
+    "content-hash": "8ee202b0fe76e12b0c821882a16704da",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.9",
+            "version": "0.7.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "9adc310064d24bda0b57279ddefb180f52d49bfd"
+                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/9adc310064d24bda0b57279ddefb180f52d49bfd",
-                "reference": "9adc310064d24bda0b57279ddefb180f52d49bfd",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/35c3929ce13f726ae5384773d7272fc402b0366d",
+                "reference": "35c3929ce13f726ae5384773d7272fc402b0366d",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.9"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.10"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-25T10:04:18+00:00"
+            "time": "2026-05-25T12:23:38+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -237,16 +237,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4"
+                "reference": "afececade2eef113f1d76cefdf06d33ca660b86f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4",
-                "reference": "42d4aa93ab0d2c1f498aca1a61cf8827d993bfe4",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/afececade2eef113f1d76cefdf06d33ca660b86f",
+                "reference": "afececade2eef113f1d76cefdf06d33ca660b86f",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.7",
+                "boundwize/structarmed": "^0.7.9",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -357,7 +357,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-24T10:24:09+00:00"
+            "time": "2026-05-25T11:40:02+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.9` to `0.7.10`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`